### PR TITLE
CASMHMS-6299: Fix PCS/TRS resource leaks and scaling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests: Error signature changed to make identifying errors easier
 - Unit tests: Reworked some existing unit tests
 - Unit tests: Numerous unit tests added to test connection states
+- Update required version of Go to 1.23 to avoid
+  https://github.com/golang/go/issues/59017
 
 ## [2.1.1] - 2024-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TRS no longer closes all idle connections when request retry limits are reached
 - Reworked several sections of code for clarity and reduced code duplication
 - Fixed bug where contexts were never being cancelled which lead to resource leaks
+- Fixed bug to prevent 2nd request if 1st request's context timed out or canceled
 - Additional tracing added for debug purposes
 - Unit tests: Now run in verbose mode so failures are more easily analyzed
 - Unit tests: Enabled TRS logging from inside unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2024-11-25
+## [3.0.0] - 2024-11-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2024-11-08
+## [2.1.2] - 2024-11-25
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ unittest:
 	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
-	go test -v ./pkg/trs_http_api/... -cover -logLevel=5
+	go test -v ./pkg/trs_http_api/... -cover -logLevel=6
 	
 	# no -v -tags musl
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ unittest:
 	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
-	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	go test -v ./pkg/trs_http_api/... -cover -logLevel=5
 	
 	# no -v -tags musl
 

--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,20 @@ all:  unittest integration
 .PHONY:  unittest integration
 
 unittest:
-	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
-	
-	# There are three different versions of go in the unit test VM
-	#ls /opt/hostedtoolcache/go
+	# There are three different versions of go in the unit test VM.
+	# Versions may change over time but can be discovered with:
+	#
+	#	ls /opt/hostedtoolcache/go
+	#
+	# Here's what's available as of Nov 20, 2024:
 	
 	#/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#/opt/hostedtoolcache/go/1.22.9/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
-	/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	#/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	
-	# The default is the latest one:
+	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
-	#go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	
 	# no -v -tags musl
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,18 @@ all:  unittest integration
 
 unittest:
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
-	ls /opt/hostedtoolcache/go
-	/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	
+	# There are three different versions of go in the unit test VM
+	#ls /opt/hostedtoolcache/go
+	
+	#/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	#/opt/hostedtoolcache/go/1.22.9/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	
+	# The default is the latest one:
+	
 	#go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	
 	# no -v -tags musl
 
 integration:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ all:  unittest integration
 
 unittest:
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
+	ls /opt/hostedtoolcache/go
 	/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	# no -v -tags musl

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all:  unittest integration
 
 unittest:
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
-	#/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
-	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	#go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	# no -v -tags musl
 
 integration:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ unittest:
 	#/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
-	
+	#
+
 	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	
 	# no -v -tags musl

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ unittest:
 	#/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#/opt/hostedtoolcache/go/1.22.9/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
-	# 
+	#
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	#
 
 	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
-	
+
 	# no -v -tags musl
 
 integration:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ unittest:
 	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
-	go test -v ./pkg/trs_http_api/... -cover -logLevel=6
+	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	
 	# no -v -tags musl
 

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ unittest:
 	#	ls /opt/hostedtoolcache/go
 	#
 	# Here's what's available as of Nov 20, 2024:
-	
+	#
 	#/opt/hostedtoolcache/go/1.21.13/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#/opt/hostedtoolcache/go/1.22.9/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
 	#/opt/hostedtoolcache/go/1.23.3/x64/bin/go test -v ./pkg/trs_http_api/... -cover -logLevel=2
-	
+	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
 	go test -v ./pkg/trs_http_api/... -cover -logLevel=2

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ unittest:
 	# 
 	# -logLevel values: 0=Panic, 1=Fatal, 2=Error 3=Warn, 4=Info, 5=Debug, 6=Trace"
 	
-	go test -v ./pkg/trs_http_api/... -cover -logLevel=2
+	go test -v ./pkg/trs_http_api/... -cover -logLevel=6
 	
 	# no -v -tags musl
 

--- a/Test/testApp.go
+++ b/Test/testApp.go
@@ -26,15 +26,14 @@ package main
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"
+	trsapi "github.com/Cray-HPE/hms-trs-app-api/v2/pkg/trs_http_api"
 	"strconv"
 	"strings"
 	"time"
-
-	trsapi "github.com/Cray-HPE/hms-trs-app-api/v2/pkg/trs_http_api"
-	"github.com/sirupsen/logrus"
 )
 
 type PayloadData struct {
@@ -61,10 +60,10 @@ func main() {
 
 
 	deadline := 10
-	numops := 1
+	numops := 2
 	opType := "GET"
 	cancelTime := -1
-	useChan := true
+	useChan := false
 
 	envstr = os.Getenv("IMPLEMENTATION")
 	if envstr == "REMOTE" {
@@ -180,27 +179,6 @@ func main() {
 			if tdone.Request.Response.StatusCode != 0 {
 				nErr++
 			}
-
-logrus.Printf("====> TDONE: task ? has pointer ? rsp %p rsp.body %p",
-			tdone.Request.Response, tdone.Request.Response.Body)
-
-type rspStuff struct {
-	task *trsapi.HttpTask
-	body []byte
-}
-rmp := rspStuff{task: tdone}
-logrus.Printf("====> RMP:  task ? has pointer ? rsp %p rsp.body %p",
-			rmp.task.Request.Response, rmp.task.Request.Response.Body)
-
-tdone.Request.Response.Body.Close()
-tdone.Request.Response.Body=nil
-
-logrus.Printf("====> TDONE: task ? has pointer ? rsp %p rsp.body %p",
-			tdone.Request.Response, tdone.Request.Response.Body)
-
-logrus.Printf("====> RMP:  task ? has pointer ? rsp %p rsp.body %p",
-			rmp.task.Request.Response, rmp.task.Request.Response.Body)
-
 			running, err := tloc.Check(&taskArray)
 			if err != nil {
 				goterr = true

--- a/Test/testApp.go
+++ b/Test/testApp.go
@@ -26,14 +26,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"
-	trsapi "github.com/Cray-HPE/hms-trs-app-api/v2/pkg/trs_http_api"
 	"strconv"
 	"strings"
 	"time"
+
+	trsapi "github.com/Cray-HPE/hms-trs-app-api/v2/pkg/trs_http_api"
+	"github.com/sirupsen/logrus"
 )
 
 type PayloadData struct {
@@ -63,7 +64,7 @@ func main() {
 	numops := 2
 	opType := "GET"
 	cancelTime := -1
-	useChan := false
+	useChan := true
 
 	envstr = os.Getenv("IMPLEMENTATION")
 	if envstr == "REMOTE" {
@@ -179,6 +180,27 @@ func main() {
 			if tdone.Request.Response.StatusCode != 0 {
 				nErr++
 			}
+
+logrus.Printf("====> TDONE: task ? has pointer ? rsp %p rsp.body %p",
+			tdone.Request.Response, tdone.Request.Response.Body)
+
+type rspStuff struct {
+	task *trsapi.HttpTask
+	body []byte
+}
+rmp := rspStuff{task: tdone}
+logrus.Printf("====> RMP:  task ? has pointer ? rsp %p rsp.body %p",
+			rmp.task.Request.Response, rmp.task.Request.Response.Body)
+
+tdone.Request.Response.Body.Close()
+tdone.Request.Response.Body=nil
+
+logrus.Printf("====> TDONE: task ? has pointer ? rsp %p rsp.body %p",
+			tdone.Request.Response, tdone.Request.Response.Body)
+
+logrus.Printf("====> RMP:  task ? has pointer ? rsp %p rsp.body %p",
+			rmp.task.Request.Response, rmp.task.Request.Response.Body)
+
 			running, err := tloc.Check(&taskArray)
 			if err != nil {
 				goterr = true

--- a/Test/testApp.go
+++ b/Test/testApp.go
@@ -61,7 +61,7 @@ func main() {
 
 
 	deadline := 10
-	numops := 2
+	numops := 1
 	opType := "GET"
 	cancelTime := -1
 	useChan := true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Cray-HPE/hms-trs-app-api/v2
 
-go 1.17
+go 1.23
 
 require (
 	github.com/Cray-HPE/hms-base/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/confluentinc/confluent-kafka-go v1.8.2/go.mod h1:u2zNLny2xq+5rWeTQjFH
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -23,13 +22,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
-github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -42,14 +36,6 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -103,7 +103,7 @@ type HttpTask struct {
 	CPolicy       ClientPolicy
 	Ignore        bool
 	context       context.Context
-	ContextCancel context.CancelFunc
+	contextCancel context.CancelFunc
 	forceInsecure bool
 }
 

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -103,7 +103,7 @@ type HttpTask struct {
 	CPolicy       ClientPolicy
 	Ignore        bool
 	context       context.Context
-	contextCancel context.CancelFunc
+	ContextCancel context.CancelFunc
 	forceInsecure bool
 }
 

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -79,7 +79,7 @@ type RetryPolicy struct {
 }
 
 type HttpTxPolicy struct {
-	Enabled					bool	// Enable or disable the policy
+	Enabled				bool	// Enable or disable the policy
 	MaxIdleConns			int
 	MaxIdleConnsPerHost		int
 	IdleConnTimeout			time.Duration

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -79,13 +79,13 @@ type RetryPolicy struct {
 }
 
 type HttpTxPolicy struct {
-	Enabled				bool	// Enable or disable the policy
-	MaxIdleConns			int
-	MaxIdleConnsPerHost		int
-	IdleConnTimeout			time.Duration
+	Enabled                 bool    // Enable or disable the policy
+	MaxIdleConns            int
+	MaxIdleConnsPerHost     int
+	IdleConnTimeout         time.Duration
 	ResponseHeaderTimeout   time.Duration
-	TLSHandshakeTimeout		time.Duration
-	DisableKeepAlives		bool
+	TLSHandshakeTimeout     time.Duration
+	DisableKeepAlives       bool
 }
 
 type ClientPolicy struct {

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -87,7 +87,6 @@ type HttpTxPolicy struct {
 	TLSHandshakeTimeout		time.Duration
 	DisableKeepAlives		bool
 }
-// {{6 0s} {true 4 4 2251808h52m22.580896768s 0s 0s false}}
 
 type ClientPolicy struct {
 	Retry    RetryPolicy

--- a/pkg/trs_http_api/models.go
+++ b/pkg/trs_http_api/models.go
@@ -83,7 +83,7 @@ type HttpTxPolicy struct {
 	MaxIdleConns			int
 	MaxIdleConnsPerHost		int
 	IdleConnTimeout			time.Duration
-	ResponseHeaderTimeout	time.Duration
+	ResponseHeaderTimeout   time.Duration
 	TLSHandshakeTimeout		time.Duration
 	DisableKeepAlives		bool
 }

--- a/pkg/trs_http_api/models_test.go
+++ b/pkg/trs_http_api/models_test.go
@@ -46,7 +46,7 @@ func GenerateStockHttpTask() (ht HttpTask) {
 		Timeout:       0,
 		CPolicy:       ClientPolicy{},
 		context:       nil,
-		contextCancel: nil,
+		ContextCancel: nil,
 	}
 	return ht
 }

--- a/pkg/trs_http_api/models_test.go
+++ b/pkg/trs_http_api/models_test.go
@@ -46,7 +46,7 @@ func GenerateStockHttpTask() (ht HttpTask) {
 		Timeout:       0,
 		CPolicy:       ClientPolicy{},
 		context:       nil,
-		ContextCancel: nil,
+		contextCancel: nil,
 	}
 	return ht
 }

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -220,12 +220,15 @@ func (c *trsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 //
 // WARNING!  The Go runtime behavior surrounding connections has changed in
 //			 more recent versions of Go.  Prior to version 1.23, if any
-//			 connection in the connection pool experiences a timeout, the
-//			 Go runtime closes ALL idle connections.  There is nothing we
-//			 can do about this in TRS, other than use a newer version of Go
-//			 that doesn't exhibit this (horrible) behavior.  Our clever
-//			 trick below with CloseIdleConnections() cannot prevent the
-//			 Go runtime from doing this.
+//			 request experiences a timeout, the Go runtime closes ALL idle
+//			 connections.  There is nothing we can do about this in TRS,
+//			 other than use a newer version of Go that doesn't exhibit this
+//			 behavior.  Issue is documented here:
+//
+//				* https://github.com/golang/go/issues/59017
+//				* https://github.com/golang/go/commit/334ce510046ad30b1be466634cf313aad3040892
+//
+//			 Will attempt to jump to Go 1.23 with this commit.
 
 func (c *trsRoundTripper) CloseIdleConnections() {
 

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -443,9 +443,6 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 		tr.ResponseHeaderTimeout = httpTxPolicy.ResponseHeaderTimeout // if 0 defaults to no timeout
 		tr.TLSHandshakeTimeout   = httpTxPolicy.TLSHandshakeTimeout   // if 0 defaults to 10s
 		tr.DisableKeepAlives	 = httpTxPolicy.DisableKeepAlives     // if 0 defaults to false
-
-		// TODO: REMOVE IF DOESN"T WORK
-		tr.ForceAttemptHTTP2 = true
 	}
 
 	// Wrap base transport with retryablehttp

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -318,6 +318,14 @@ func (c *trsRoundTripper) trsCheckRetry(ctx context.Context, resp *http.Response
 
 			//wrapperLogger.Errorf("trsCheckRetry: skipCloseCount now %v (http timeout)", c.skipCloseCount)
 
+			// The retryablehttp documentation states that if a custom
+			// CheckRetry() wrapper decides not to retry (ie. return false),
+			// it is responsible for draining and closing the response body.
+			if resp != nil && resp.Body != nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
+
 			return false, err	// skip it
 		}
 
@@ -328,6 +336,14 @@ func (c *trsRoundTripper) trsCheckRetry(ctx context.Context, resp *http.Response
 			c.skipCloseMutex.Unlock()
 
 			//wrapperLogger.Errorf("trsCheckRetry: skipCloseCount now %v (ctx timeout)", c.skipCloseCount)
+
+			// The retryablehttp documentation states that if a custom
+			// CheckRetry() wrapper decides not to retry (ie. return false),
+			// it is responsible for draining and closing the response body.
+			if resp != nil && resp.Body != nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
 
 			return false, err	// skip it
 		}
@@ -376,7 +392,6 @@ func (c *trsRoundTripper) trsCheckRetry(ctx context.Context, resp *http.Response
 			// The retryablehttp documentation states that if a custom
 			// CheckRetry() wrapper decides not to retry (ie. return false),
 			// it is responsible for draining and closing the response body.
-
 			if resp != nil && resp.Body != nil {
 				_, _ = io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -545,7 +545,7 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 		retryMax:   cpack.insecure.RetryMax, // secure and insecure contain same value
 		retryCount: 0,
 	}
-	tct.task.context = context.WithValue(req.Request.Context(), trsRetryCountKey, trsWR)
+	tct.task.context = context.WithValue(tct.task.context, trsRetryCountKey, trsWR)
 
 	// Link retryablehttp's request context to the caller's request context
 	req.Request = req.Request.WithContext(tct.task.context)

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -452,7 +452,9 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 	// Create the httpretryable client and start configuring it
 	client = retryablehttp.NewClient()
 
-	client.HTTPClient.Transport = retryabletr
+// XXXX
+//	client.HTTPClient.Transport = retryabletr
+client.HTTPClient.Transport = tr
 
 	// We could set a global http timeout for all users of the client but
 	// that's a bit inflexible.  Let's keep it at the default (unlimited)
@@ -463,7 +465,8 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 	//client.HTTPClient.Timeout   = task.Timeout * 9 / 10
 
 	// Wrap httpretryable's DefaultRetryPolicy() so we can override
-	client.CheckRetry = retryabletr.trsCheckRetry
+// XXXX
+//	client.CheckRetry = retryabletr.trsCheckRetry
 
 	// Configure the httpretryable client retry count
 	if (task.CPolicy.Retry.Retries >= 0) {
@@ -573,9 +576,12 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	// Create child context with timeout and our own retry counter
 
 	baseCtx, cancel := context.WithTimeout(tloc.ctx, tct.task.Timeout)
-	ctxWithValue := context.WithValue(baseCtx, trsRetryCountKey, trsWR)
+// XXXX
+//	ctxWithValue := context.WithValue(baseCtx, trsRetryCountKey, trsWR)
 
-	tct.task.context = ctxWithValue
+// XXXX
+//	tct.task.context = ctxWithValue
+tct.task.context = baseCtx
 	tct.task.contextCancel = cancel
 
 	// Create a retryablehttp request using the caller's request
@@ -768,15 +774,6 @@ func (tloc *TRSHTTPLocal) Close(taskList *[]HttpTask) {
 		tloc.taskMutex.Unlock()
 
 	}
-// See if this helps memory leak
-for k := range tloc.clientMap {
-	if (tloc.clientMap[k].insecure != nil) {
-		tloc.clientMap[k].insecure.HTTPClient.CloseIdleConnections()
-	}
-	if (tloc.clientMap[k].secure != nil) {
-		tloc.clientMap[k].secure.HTTPClient.CloseIdleConnections()
-	}
-}
 
 	tloc.Logger.Tracef("Close() completed")
 }

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -456,7 +456,8 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	tloc.clientMutex.Lock()
 	if _, ok := tloc.clientMap[tct.task.CPolicy]; !ok {
 		httpLogger := logrus.New()
-		httpLogger.SetLevel(tloc.Logger.GetLevel())
+		httpLogger.SetLevel(logrus.ErrorLevel)
+		httpLogger.SetLevel(logrus.InfoLevel)
 
 		// Do not use leveled logging for now.  See explanation further
 		// up in the source code.
@@ -504,7 +505,6 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 		return
 	}
 
-// TODO: ONLY CONFIG IF NO TX POLICY SO IT CAN BE DISABLED IN FIELD BY DEPLOYMENT CHANGE
 	// Add our own retry counter to the context
 	trsWR := &trsWrappedReq{
 		orig:       tct.task.Request, // Assign the original request

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -399,7 +399,7 @@ func (c *trsRoundTripper) trsCheckRetry(ctx context.Context, resp *http.Response
 			c.skipCloseMutex.Unlock()
 
 			//wrapperLogger.Errorf("trsCheckRetry: skipCloseCount now %v and err is %v", c.skipCloseCount, err)
-			
+
 			return false, err
 		}
 	}
@@ -745,8 +745,8 @@ func (tloc *TRSHTTPLocal) Close(taskList *[]HttpTask) {
 			v.contextCancel()
 
 			// The caller should have closed the response body, but we'll also
-			// do it here to both prevent resource leaks.  Note that if that
-			// was the case, that connection was closed by the above cancel.
+			// do it here to prevent resource leaks.  Note that if that was
+			// the case, that connection was closed by the above cancel.
 
 			if v.Request.Response != nil && v.Request.Response.Body != nil {
 				_, _ = io.Copy(io.Discard, v.Request.Response.Body)
@@ -796,5 +796,4 @@ func (tloc *TRSHTTPLocal) Cleanup() {
 	}
 	tloc.Logger.Tracef("Cleanup() completed")
 	// this really just a big red button to STOP ALL? b/c im not clearing any memory
-	// TEST
 }

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -220,16 +220,16 @@ func (c *trsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 // occasionally after a two hour period, not a big deal.
 //
 // WARNING!  The Go runtime behavior surrounding connections has changed in
-//			 more recent versions of Go.  Prior to version 1.23, if any
-//			 request experiences a timeout, the Go runtime closes ALL idle
-//			 connections.  There is nothing we can do about this in TRS,
-//			 other than use a newer version of Go that doesn't exhibit this
-//			 behavior.  Issue is documented here:
+//           more recent versions of Go.  Prior to version 1.23, if any
+//           request experiences a timeout, the Go runtime closes ALL idle
+//           connections.  There is nothing we can do about this in TRS,
+//           other than use a newer version of Go that doesn't exhibit this
+//           behavior.  Issue is documented here:
 //
-//				* https://github.com/golang/go/issues/59017
-//				* https://github.com/golang/go/commit/334ce510046ad30b1be466634cf313aad3040892
+//           * https://github.com/golang/go/issues/59017
+//           * https://github.com/golang/go/commit/334ce510046ad30b1be466634cf313aad3040892
 //
-//			 Will attempt to jump to Go 1.23 with this commit.
+//           Will attempt to jump to Go 1.23 with this commit.
 
 //var wrapperLogger *logrus.Logger	// only uncomment if debugging wrapper issues
 
@@ -339,13 +339,13 @@ func (c *trsRoundTripper) trsCheckRetry(ctx context.Context, resp *http.Response
 		// connections when they do happen is not a big deal.
 		//
 		// if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		//		c.skipCloseCount++
+		//     c.skipCloseCount++
 		//
-		//		c.skipCloseMutex.Unlock()
+		//     c.skipCloseMutex.Unlock()
 		//
-		//		wrapperLogger.Errorf("trsCheckRetry: skipCloseCount now %v (ctx timeout)", c.skipCloseCount)
+		//     wrapperLogger.Errorf("trsCheckRetry: skipCloseCount now %v (ctx timeout)", c.skipCloseCount)
 		//
-		//		return false, err	// skip it
+		//     return false, err  // skip it
 		// }
 
 		c.skipCloseMutex.Unlock()
@@ -417,7 +417,7 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 		tr.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
-	} else {	// insecure
+	} else {     // secure
 		tr.TLSClientConfig = &tls.Config{
 			RootCAs: tloc.CACertPool,
 		}
@@ -557,10 +557,10 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	// We'll attach this to the context further below so that it has access
 	// to it
 	trsWR := &trsWrappedReq{
-		orig:       tct.task.Request, 		 // Core request
-		retryCount: 0,						 // Counter for CLIC()
+		orig:       tct.task.Request,        // Core request
+		retryCount: 0,                       // Counter for CLIC()
 		retryMax:   cpack.insecure.RetryMax, // CLIC() will need access to this
-											 // same for both secure & insecure
+		                                     // same for both secure & insecure
 	}
 
 	// Create child context with timeout and our own retry counter

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -417,7 +417,7 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 
 	// Log this client's configuration
 	tloc.Logger.Errorf("Created %s client with incoming policy %v " +
-					   "(to's %s and %s) (ll %v) (cnum=%v)",
+					   "(to's %s and %s) (ll %v) (cpnum=%v)",
 					   clientType, task.CPolicy, task.Timeout,
 					   client.HTTPClient.Timeout, tloc.Logger.GetLevel(),
 					   len(tloc.clientMap) + 1)

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -545,7 +545,8 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 		retryMax:   cpack.insecure.RetryMax, // secure and insecure contain same value
 		retryCount: 0,
 	}
-	tct.task.context = context.WithValue(tct.task.context, trsRetryCountKey, trsWR)
+	//tct.task.context = context.WithValue(tct.task.context, trsRetryCountKey, trsWR)
+	tct.task.context = context.WithValue(req.Request.Context(), trsRetryCountKey, trsWR)
 
 	// Link retryablehttp's request context to the caller's request context
 	req.Request = req.Request.WithContext(tct.task.context)

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -441,8 +441,8 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 	// incoming task's context timeout so it can be handled before the
 	// context timeout.  We may want to revisit this if requests with
 	// different timeout values are used
-
-	client.HTTPClient.Timeout   = task.Timeout * 9 / 10
+	//
+	//client.HTTPClient.Timeout   = task.Timeout * 9 / 10
 
 	// Wrap httpretryable's DefaultRetryPolicy() so we can prevent
 	// retries when desired

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -443,11 +443,12 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 	}
 
 	// Wrap base transport with retryablehttp
-	retryabletr := &trsRoundTripper{
-		transport:                             tr,
-		closeIdleConnectionsFn:                tr.CloseIdleConnections,
-		timeLastClosedOrReachedZeroCloseCount: time.Now(),
-	}
+// XXXX
+//	retryabletr := &trsRoundTripper{
+//		transport:                             tr,
+//		closeIdleConnectionsFn:                tr.CloseIdleConnections,
+//		timeLastClosedOrReachedZeroCloseCount: time.Now(),
+//	}
 
 	// Create the httpretryable client and start configuring it
 	client = retryablehttp.NewClient()
@@ -566,12 +567,13 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	// Wrap the request so trsCheckRetry() can keep its own retry count
 	// We'll attach this to the context further below so that it has access
 	// to it
-	trsWR := &trsWrappedReq{
-		orig:       tct.task.Request,        // Core request
-		retryCount: 0,                       // Counter for CLIC()
-		retryMax:   cpack.insecure.RetryMax, // CLIC() will need access to this
-		                                     // same for both secure & insecure
-	}
+// XXXX
+//	trsWR := &trsWrappedReq{
+//		orig:       tct.task.Request,        // Core request
+//		retryCount: 0,                       // Counter for CLIC()
+//		retryMax:   cpack.insecure.RetryMax, // CLIC() will need access to this
+//		                                     // same for both secure & insecure
+//	}
 
 	// Create child context with timeout and our own retry counter
 

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -583,8 +583,6 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 		tloc.Logger.Tracef("No response received")
 	}
 
-tloc.Logger.Errorf("----> ExecuteTask(): task %v has pointer %p rsp %p rsp.body %p",
-           tct.task.id, tct.task, tct.task.Request.Response, tct.task.Request.Response.Body)
 	tct.taskListChannel <- tct.task
 }
 
@@ -631,13 +629,11 @@ func (tloc *TRSHTTPLocal) Launch(taskList *[]HttpTask) (chan *HttpTask, error) {
 			(*taskList)[ii].TimeStamp = time.Now().Format(time.RFC3339Nano)
 		}
 
-tloc.Logger.Errorf("----> Launch():      task %v has pointer %p (incoming)", (*taskList)[ii].id, &(*taskList)[ii])
 		//Setup the channel stuff
 		tct := taskChannelTuple{
 			taskListChannel: taskListChannel,
 			task:            &(*taskList)[ii],
 		}
-tloc.Logger.Errorf("----> Launch():      task %v has pointer %p (tct)", tct.task.id, tct.task)
 		tloc.taskMutex.Lock()
 		tloc.taskMap[(*taskList)[ii].id ] = &tct
 		tloc.taskMutex.Unlock()

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -457,7 +457,7 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	if _, ok := tloc.clientMap[tct.task.CPolicy]; !ok {
 		httpLogger := logrus.New()
 		httpLogger.SetLevel(logrus.ErrorLevel)
-		httpLogger.SetLevel(logrus.InfoLevel)
+		httpLogger.SetLevel(logrus.ErrorLevel)
 
 		// Do not use leveled logging for now.  See explanation further
 		// up in the source code.

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -435,17 +435,15 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 
 	client.HTTPClient.Transport = retryabletr
 
-	// Without setting a timeout on the http request, it could hang for an
-	// indefinite period of time.  The task's context timeout does put a cap
-	// on this and will cancel it.  But, let's constrain it to 90% of the
-	// incoming task's context timeout so it can be handled before the
-	// context timeout.  We may want to revisit this if requests with
-	// different timeout values are used
+	// We could set a global http timeout for all users of the client but
+	// that's a bit inflexible.  Let's keep it at the default (unlimited)
+	// and use the user provided context timeout to limit the request.
+	// The context timeout they provide could be different from caller to
+	// caller as well.
 	//
 	//client.HTTPClient.Timeout   = task.Timeout * 9 / 10
 
-	// Wrap httpretryable's DefaultRetryPolicy() so we can prevent
-	// retries when desired
+	// Wrap httpretryable's DefaultRetryPolicy() so we can override
 	client.CheckRetry = retryabletr.trsCheckRetry
 
 	// Configure the httpretryable client retry count

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -457,17 +457,17 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	if _, ok := tloc.clientMap[tct.task.CPolicy]; !ok {
 		httpLogger := logrus.New()
 		httpLogger.SetLevel(logrus.ErrorLevel)
-		httpLogger.SetLevel(logrus.ErrorLevel)
 
 		// Do not use leveled logging for now.  See explanation further
 		// up in the source code.
 		//
-		//retryablehttpLogger := retryablehttp.LeveledLogger(&leveledLogrus{httpLogger})
+		retryablehttpLogger := retryablehttp.LeveledLogger(&leveledLogrus{httpLogger})
 
 		cpack = new(clientPack)
 
 		cpack.insecure = createClient(tct.task, tloc, "insecure")
-		cpack.insecure.Logger = httpLogger
+		//cpack.insecure.Logger = httpLogger
+		cpack.insecure.Logger = retryablehttpLogger
 
 		if (tloc.CACertPool != nil) {
 			cpack.secure = createClient(tct.task, tloc, "secure")

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -277,7 +277,6 @@ TESTLOGGER.Errorf("                    closing")
 		// Call next level down
 		c.closeIdleConnectionsFn()
 	}
-TESTLOGGER.Errorf("                   RESETTING SKIP COUNTER!!!! ===> ERROR")	// REMOVE ME
 TESTLOGGER.Errorf("                   done closing")
 }
 

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -592,8 +592,9 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 		tloc.Logger.Tracef("Using secure client to send request")
 		tct.task.Request.Response, tmpError = cpack.secure.Do(req)
 
-		//If the error is a TLS error, fall back to insecure and log it.
-		if (tmpError != nil) {
+		// Fall back to insecure only if the enclosing context was not
+		// cancelled or timed out.
+		if (tmpError != nil && tct.task.context.Err() != nil {
 			// But first make sure we drain/close the body of the failed
 			// response, if there was one
 			if tct.task.Request.Response != nil && tct.task.Request.Response.Body != nil {
@@ -615,6 +616,9 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 	} else {
 		tloc.Logger.Tracef("No response received")
 	}
+
+	// TODO: Consider cancelling the context for this task here instead of
+	// leaving it up to the caller
 
 	tct.taskListChannel <- tct.task
 }

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -594,7 +594,7 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 
 		// Fall back to insecure only if the enclosing context was not
 		// cancelled or timed out.
-		if (tmpError != nil && tct.task.context.Err() != nil {
+		if tmpError != nil && tct.task.context.Err() != nil {
 			// But first make sure we drain/close the body of the failed
 			// response, if there was one
 			if tct.task.Request.Response != nil && tct.task.Request.Response.Body != nil {

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -594,7 +594,7 @@ func ExecuteTask(tloc *TRSHTTPLocal, tct taskChannelTuple) {
 
 		// Fall back to insecure only if the enclosing context was not
 		// cancelled or timed out.
-		if tmpError != nil && tct.task.context.Err() != nil {
+		if tmpError != nil && tct.task.context.Err() == nil {
 			// But first make sure we drain/close the body of the failed
 			// response, if there was one
 			if tct.task.Request.Response != nil && tct.task.Request.Response.Body != nil {

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -417,10 +418,10 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 
 	// Log this client's configuration
 	tloc.Logger.Errorf("Created %s client with incoming policy %v " +
-					   "(to's %s and %s) (ll %v) (cpnum=%v)",
+					   "(to's %s and %s) (ll %v) (cpnum=%v) (goVer=%v)",
 					   clientType, task.CPolicy, task.Timeout,
 					   client.HTTPClient.Timeout, tloc.Logger.GetLevel(),
-					   len(tloc.clientMap) + 1)
+					   len(tloc.clientMap) + 1, runtime.Version())
 
 	return client
 }

--- a/pkg/trs_http_api/trshttp_local.go
+++ b/pkg/trs_http_api/trshttp_local.go
@@ -418,7 +418,7 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 	// context timeout.  We may want to revisit this if requests with
 	// different timeout values are used
 
-//	client.HTTPClient.Timeout   = task.Timeout * 9 / 10
+	client.HTTPClient.Timeout   = task.Timeout * 9 / 10
 
 	// Wrap httpretryable's DefaultRetryPolicy() so we can prevent
 	// retries when desired
@@ -449,7 +449,7 @@ func createClient(task *HttpTask, tloc *TRSHTTPLocal, clientType string) (client
 
 	if (httpTxPolicy.Enabled) {
 		tloc.Logger.Errorf("    tx.MaxIdleConns:           %v", tr.MaxIdleConns)
-		tloc.Logger.Errorf("    tx.MaxIdleConnsPerHost:    %v", tr.MaxConnsPerHost)
+		tloc.Logger.Errorf("    tx.MaxIdleConnsPerHost:    %v", tr.MaxIdleConnsPerHost)
 		tloc.Logger.Errorf("    tx.IdleConnTimeout:        %v", tr.IdleConnTimeout)
 		tloc.Logger.Errorf("    tx.ResponseHeaderTimeout:  %v", tr.ResponseHeaderTimeout)
 		tloc.Logger.Errorf("    tx.TLSHandshakeTimeout:    %v", tr.TLSHandshakeTimeout)

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -48,9 +48,13 @@ import (
 var svcName = "TestMe"
 
 // Note for unit test and TRS loggers: Log level can be controlled by
-// by modifying the 
+// by modifying the -logLevel command line option in the Makefile
+
 var logLevel logrus.Level	// use this for more than logrus
 
+// TestMain is not a test.  It runs before all other tests so that it can
+// do any necessary initialization.  Here we pars the command line arges
+// so we can apply any log level override for the unit test loggers
 func TestMain(m *testing.M) {
 	var logLevelInt int
 
@@ -70,7 +74,7 @@ func TestMain(m *testing.M) {
 }
 
 // Create a logger for trs_http_api (not unit tests) so we can see what's
-// going on in TRS when we hit errors
+// going on in TRS when we hit issues.
 func createLogger() *logrus.Logger {
 	trsLogger := logrus.New()
 
@@ -138,7 +142,8 @@ func hasUserAgentHeader(r *http.Request) bool {
     }
 
     _,ok := r.Header["User-Agent"]
-	return ok
+
+    return ok
 }
 
 // Check header for "Trs-Fail-All-Retries"
@@ -462,12 +467,12 @@ func TestLaunchTimeout(t *testing.T) {
 //			* Marked "dirty" and could get cleaned up any time since the
 //			  body was drained
 //
-//			* If/wen IdleConnTimeout is exceeded (by default is 0 which means
+//			* If/when IdleConnTimeout is exceeded (by default is 0 which means
 //			  no timeout in place), it will be closed and:
 //
 //			  	* I couldn't find a definitive answer if a minimal
 //				  resource leak (which would NOT include body data) would
-//			      be permanent or not in the Go client
+//			          be permanent or not in the Go client
 //				* Prior OS resource leak should now be freed (not sure I believe)
 //				* Prior Istio resource leak should now be freed (not sure I believe)
 //
@@ -477,8 +482,9 @@ func TestLaunchTimeout(t *testing.T) {
 //			* OS connection state:        open, unusable (resource leak)
 //			* Istio connection state:     open, unusable (resource leak)
 //
-//			* If/wen IdleConnTimeout is exceeded (by default is 0 which means
-//			  no timeout in place), it will be closed and:
+//			* If/when IdleConnTimeout is exceeded (by default is 0 which means
+//			  no timeout in place), OR if/when a context times out or is cancelled,
+//			  it will be closed and:
 //
 //				* Go client resource leak (including body data) will remain
 //				* Prior OS resource leak should now be freed (not sure I believe)
@@ -761,7 +767,7 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 	t.Logf("")
 
 	if logLevel < logrus.ErrorLevel {
-		return 
+		return
 	}
 
 	t.Logf("   nTasks:              %v", a.nTasks)
@@ -958,7 +964,7 @@ func TestConnsWithHttpTxPolicy_PcsLargeBusy(t *testing.T) {
 	nIssues             := 1000
 	maxIdleConnsPerHost := 8000  // We're only using one Host server so pretend
 	maxIdleConns        := 8000  // 8000 requests / 4 per host = 2000 BMCs
-	pcsStatusTimeout    := 60    // Increase for pitiful unit test vm 
+	pcsStatusTimeout    := 60    // Increase for pitiful unit test vm
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)
 }
@@ -1210,7 +1216,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	// Connection stays open if the body is never closed and is not reusable
 	// for any other requests (unless body is later drained/closed)
 	//
- 	// However, because it was marked "dirty" it can get cleaned up by
+	// However, because it was marked "dirty" it can get cleaned up by
 	// the system at any time. I've seen that using 'ss' in the tests
 	// can force this to happen immediately after tasks complete if the
 	// number of open connections is greater than maxIdleConnsPerHost
@@ -1411,8 +1417,8 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
 	if err != nil {
-        t.Fatalf("=====> ERROR: Failed to create request: %v <=====", err)
-    }
+		t.Fatalf("=====> ERROR: Failed to create request: %v <=====", err)
+	}
 
 	// Set any necessary headers
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1641,7 +1641,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 					nBodyDrainSkipped++
 
-					if logLevel == logrus.DebugLevel {
+					if logLevel >= logrus.DebugLevel {
 						t.Logf("Skipping draining response body for task %v", tsk.GetID())
 					}
 				} else {
@@ -1650,7 +1650,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 				nBodyClosesSkipped++
 
-				if logLevel == logrus.DebugLevel {
+				if logLevel >= logrus.DebugLevel {
 					t.Logf("Skipping closing response body for task %v", tsk.GetID())
 				}
 				continue
@@ -1665,7 +1665,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 				nBodyDrainSkipped++
 
-				if logLevel == logrus.DebugLevel {
+				if logLevel >= logrus.DebugLevel {
 					t.Logf("Skipping draining response body for task %v", tsk.GetID())
 				}
 			} else {

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -919,7 +919,7 @@ t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
-//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks              := 1000
 	nIssues             := 4
@@ -932,7 +932,7 @@ func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks              := 4000
 	nIssues             := 10

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"encoding/pem"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -1419,6 +1420,9 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	t.Logf("Calling tloc.CreateTaskList() to create %v tasks for URL %v", a.nTasks, srv.URL)
 	tList := tloc.CreateTaskList(a.tListProto, a.nTasks)
 
+for i := 0; i < len(tList); i++ {
+  t.Errorf("====> TEST 1: tsk %v has pointer %s", tList[i].id, fmt.Sprintf("%p", &tList[i]))
+}
 	// Configure any requested retries and put at start of task list
 
 	nRetries = a.nSuccessRetries	// this signals the handler
@@ -1616,6 +1620,10 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 	for _, tsk := range(tList) {
 		// Skip closing any requested response bodies
+t.Errorf("====> TEST 2: tsk %v has pointer %s rsp %s rsp.body %s", tsk.id, 
+         fmt.Sprintf("%p", &tsk),
+         fmt.Sprintf("%p", &tsk.Request.Response),
+         fmt.Sprintf("%p", &tsk.Request.Response.Body))
 
 		if nBodyClosesSkipped < a.nSkipCloseBody {
 			if tsk.Request.Response != nil && tsk.Request.Response.Body != nil {

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -799,9 +799,9 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // MANY CONNECTION TESTS BELOW ARE MARKED AS SKIP BECAUSE:
 //
 //	* The unit test framework in GitHub only allows 10 minutes for ALL
-//	  unit tests to complete
+//	  unit tests to complete.  It would take hours to run them all.
 //
-//	* Connection and task counts of more than 1000 sometimes do not match
+//	* Connection and task counts of at higher scale sometimes do not match
 //	  what one would expect to see based on observations at smaller
 //	  connection and task counts. That is not to say that things are not
 //	  behaving correctly. It's more likely the case that at higher counts
@@ -811,10 +811,11 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 //	  system level is nearly impossible. The counts that the unit tests
 //	  do detect at these higher counts are within a very reasonable small
 //	  deviation from what one would expect. For these reasons, the tests
-//	  at higher counts are not enabled by default.  When changes to TRS
-//	  are made in the future, developers should re-enable them and
-//	  reconfirm that the resultant behavior is still within a reasonable
-//	  deviation.
+//	  at higher counts are not enabled by default.
+//
+//	  When changes to TRS are made in the future, developers should re-
+//	  enable them and reconfirm that the resultant behavior is still within
+//	  a reasonable deviation.
 //
 ///////////////////////////////////////////////////////////////////////////
 
@@ -825,7 +826,7 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 
 func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1
@@ -835,7 +836,8 @@ func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
 func TestConnsWithNoHttpTxPolicy_ModeratlyBusy(t *testing.T) {
 
-t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	//t.Skip()	/***************** COMMENT TO RUN TEST *****************/
+
 	nTasks  := 1000
 	nIssues := 1
 
@@ -844,7 +846,7 @@ t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 func TestConnsWithNoHttpTxPolicy_Busy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks  := 4000
 	nIssues := 200
@@ -854,7 +856,7 @@ func TestConnsWithNoHttpTxPolicy_Busy(t *testing.T) {
 
 func TestConnsWithNoHttpTxPolicy_VeryBusy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks  := 8000
 	nIssues := 40
@@ -898,7 +900,7 @@ func testConnsWithNoHttpTxPolicy(t *testing.T, nTasks int, nIssues int) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 4
 	nIssues             := 4
@@ -911,7 +913,8 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 
-t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	//t.Skip()	/***************** COMMENT TO RUN TEST *****************/
+
 	nTasks              := 1000
 	nIssues             := 5
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy
@@ -923,7 +926,7 @@ t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 1000
 	nIssues             := 4
@@ -936,7 +939,7 @@ func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 4000
 	nIssues             := 10
@@ -949,7 +952,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsLargeBusy(t *testing.T) {
 
-//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+//	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 8000
 	nIssues             := 1000
@@ -962,7 +965,7 @@ func TestConnsWithHttpTxPolicy_PcsLargeBusy(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsHugeBusy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks               := 24000  // TRS can handle larger but unit test vm can't
 	nIssues              := 2

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1250,7 +1250,6 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
 	a.openAfterTasksComplete = a.openAfterLaunch
-	a.openAfterBodyClose     = a.openAfterLaunch
 
 	// Truncate the good connections down to MaxIdleConnsPerHost
 
@@ -1260,6 +1259,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	}
 	openAfter = openAfter + a.nSkipDrainBody
 
+	a.openAfterBodyClose     = openAfter
 	a.openAfterCancel        = openAfter
 	a.openAfterClose         = openAfter
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -819,9 +819,33 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // if they updated to the latest TRS without configuring the transport,
 // which is a newer feature of TRS.
 
+func JoshOne(t *testing.T) {
+
+	nTasks  := 2	// default MaxIdleConnsPerHost
+	nIssues := 1
+
+	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
+}
+
+func JoshTwo(t *testing.T) {
+
+	nTasks  := 3	// default MaxIdleConnsPerHost
+	nIssues := 1
+
+	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
+}
+
+func JoshThree(t *testing.T) {
+
+	nTasks  := 4	// default MaxIdleConnsPerHost
+	nIssues := 1
+
+	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
+}
+
 func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
-//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1385,7 +1385,7 @@ func testConns(t *testing.T, a testConnsArg) {
 	// Cleaning up the task list system should close all connections.  Verify
 
 	time.Sleep(sleepTimeToStabilizeConns)
-	t.Logf("Testing connections after task list cleaned up")
+	t.Logf("Testing connections after task list cleaned up (0)")
 	testOpenConnections(t, 0)
 
 	t.Logf("Closing the server")
@@ -1398,7 +1398,7 @@ func testConns(t *testing.T, a testConnsArg) {
 func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest.Server) {
 	// Verify correct number of open conections at start
 
-	t.Logf("Testing connections at start")
+	t.Logf("Testing connections at start (%v)", a.openAtStart)
 	testOpenConnections(t, a.openAtStart)
 
 	// Create an http request
@@ -1482,7 +1482,6 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	// All tasks should now be runnind and all connections should be in
 	// the ESTAB(LISHED) state
 
-	t.Logf("Testing connections after Launch")
 	testOpenConnections(t, a.openAfterLaunch)
 
 	// If asked, here we attempt to close response bodies for tasks that have
@@ -1519,14 +1518,14 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		// Wait for underlying system to perform actions on connections
 		time.Sleep(sleepTimeToStabilizeConns)
 
-		t.Logf("Testing connections after non-retry request bodies closed (oabc=%v nfr=%v)",
-			    a.openAfterBodyClose, a.nFailRetries)
-
 		oConns := nWaitedFor
 		if nWaitedFor > a.maxIdleConnsPerHost {
 			oConns = a.maxIdleConnsPerHost
 		}
 		oConns += a.nFailRetries
+
+		t.Logf("Testing connections after non-retry request bodies closed (%v) (oabc=%v nfr=%v)",
+			    oConns, a.openAfterBodyClose, a.nFailRetries)
 
 		testOpenConnections(t, oConns)
 	}
@@ -1565,13 +1564,14 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		// Wait for underlying system to perform actions on connections
 
 		time.Sleep(sleepTimeToStabilizeConns)
-		t.Logf("Testing connections after non-timeout request bodies closed")
 
 		oConns := nWaitedFor
 		if nWaitedFor > a.maxIdleConnsPerHost {
 			oConns = a.maxIdleConnsPerHost
 		}
 		oConns += a.nHttpTimeouts
+
+		t.Logf("Testing connections after non-timeout request bodies closed (%v)", oConns)
 
 		testOpenConnections(t, oConns)
 	}
@@ -1596,7 +1596,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		time.Sleep(5 * time.Second)
 	}
 
-	t.Logf("Testing connections after tasks complete")
+	t.Logf("Testing connections after tasks complete (%v)", a.openAfterTasksComplete)
 	testOpenConnections(t, a.openAfterTasksComplete)
 
 	// Set up custom read closer to test response body closure
@@ -1672,7 +1672,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	// Wait for underlying system to perform actions on connections
 	time.Sleep(sleepTimeToStabilizeConns)
 
-	t.Logf("Testing connections after response bodies closed")
+	t.Logf("Testing connections after response bodies closed (%v)", a.openAfterBodyClose)
 	testOpenConnections(t, a.openAfterBodyClose)
 
 	// TRS users are not required to call tloc.Cancel() so lets test both ways
@@ -1687,7 +1687,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 		time.Sleep(sleepTimeToStabilizeConns)
 
-		t.Logf("Testing connections after task list cancelled")
+		t.Logf("Testing connections after task list cancelled (%v)", a.openAfterCancel)
 		testOpenConnections(t, a.openAfterCancel)
 	}
 
@@ -1701,7 +1701,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 	time.Sleep(sleepTimeToStabilizeConns)
 
-	t.Logf("Testing connections after task list closed")
+	t.Logf("Testing connections after task list closed (%v)", a.openAfterClose)
 	testOpenConnections(t, a.openAfterClose)
 
 	// Verify that tloc.Close() did indeed close the response bodies that
@@ -1741,7 +1741,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 	if a.testIdleConnTimeout && a.tListProto.CPolicy.Tx.Enabled {
 		// TODO: Should also comfirm no client "other" connections as well
-		t.Logf("Testing connections after idleConnTimeout")
+		t.Logf("Testing connections after idleConnTimeout (0)")
 
 		time.Sleep(a.tListProto.CPolicy.Tx.IdleConnTimeout)
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1570,7 +1570,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 					t.Logf("Response headers: %s", tList[i].Request.Response.Header)
 				}
 			}
-			tList[i].contextCancel()
+			tList[i].ContextCancel()
 		}
 
 		// Wait for underlying system to perform actions on connections

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1253,13 +1253,19 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 
 	// Truncate the good connections down to MaxIdleConnsPerHost
 
-	openAfter = a.openAfterLaunch - a.nSkipDrainBody
+	openAfter = a.openAfterTasksComplete - a.nSkipDrainBody
 	if openAfter > a.maxIdleConnsPerHost {
 		openAfter = a.maxIdleConnsPerHost
 	}
 	openAfter = openAfter + a.nSkipDrainBody
 
 	a.openAfterBodyClose     = openAfter
+
+	openAfter = a.openAfterBodyClose - a.nSkipDrainBody
+	if openAfter > a.maxIdleConnsPerHost {
+		openAfter = a.maxIdleConnsPerHost
+	}
+
 	a.openAfterCancel        = openAfter
 	a.openAfterClose         = openAfter
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -952,7 +952,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsLargeBusy(t *testing.T) {
 
-//	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 8000
 	nIssues             := 1000

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -831,6 +831,7 @@ func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
 func TestConnsWithNoHttpTxPolicy_ModeratlyBusy(t *testing.T) {
 
+t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 	nTasks  := 1000
 	nIssues := 1
 
@@ -906,6 +907,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 
+t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 	nTasks              := 1000
 	nIssues             := 5
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy
@@ -917,7 +919,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks              := 1000
 	nIssues             := 4

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -906,7 +906,7 @@ func testConnsWithNoHttpTxPolicy(t *testing.T, nTasks int, nIssues int) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 
-	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
+	//t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 4
 	nIssues             := 4
@@ -919,7 +919,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 
-	//t.Skip()	/***************** COMMENT TO RUN TEST *****************/
+	t.Skip()	/***************** COMMENT TO RUN TEST *****************/
 
 	nTasks              := 1000
 	nIssues             := 5

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -188,7 +188,7 @@ var handlerLogger *testing.T	// Allows logging in the handlers
 var handlerSleep int    = 2 // time to sleep to simulate network/BMC delays
 var retrySleep int      = 0 // time to sleep before returning 503 for retry
 var nRetries int32      = 0 // how many retries before returning success
-var nHttpTimeouts int   = 0 // how many context timeouts
+var nCtxTimeouts int    = 0 // how many context timeouts
 
 func launchHandler(w http.ResponseWriter, req *http.Request) {
 	if (logLevel >= logrus.TraceLevel) {
@@ -735,7 +735,7 @@ type testConnsArg struct {
 	nFailRetries           int       // Number of retries to fail
 	nSkipDrainBody         int       // Number of response bodies to skip draining before closing
 	nSkipCloseBody         int       // Number of response bodies to skip closing
-	nHttpTimeouts          int       // Number of context timeouts
+	nCtxTimeouts           int       // Number of context timeouts
 	testIdleConnTimeout    bool 	 // Test idle connection timeout
 	runSecondTaskList	   bool      // Run a second task list after the first with same server
 	openAtStart            int       // Expected number of ESTAB connections at beginning
@@ -765,7 +765,7 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 	t.Logf("   nFailRetries:        %v", a.nFailRetries)
 	t.Logf("   nSkipDrainBody:      %v", a.nSkipDrainBody)
 	t.Logf("   nSkipCloseBody:      %v", a.nSkipCloseBody)
-	t.Logf("   nHttpTimeouts:       %v", a.nHttpTimeouts)
+	t.Logf("   nCtxTimeouts:        %v", a.nCtxTimeouts)
 	t.Logf("")
 	t.Logf("   testIdleConnTimeout: %v", a.testIdleConnTimeout)
 	t.Logf("   runSecondTaskList:   %v", a.runSecondTaskList)
@@ -818,14 +818,6 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // configure the http transport.  This would be the case for TRS users
 // if they updated to the latest TRS without configuring the transport,
 // which is a newer feature of TRS.
-
-func TestThree(t *testing.T) {
-
-	nTasks  := 4	// default MaxIdleConnsPerHost
-	nIssues := 1
-
-	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
-}
 
 func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
@@ -1063,7 +1055,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1086,7 +1078,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1106,7 +1098,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = nIssues
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 
@@ -1147,7 +1139,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = nIssues
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1183,7 +1175,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = nIssues
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1220,7 +1212,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = nIssues
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1245,7 +1237,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = nIssues
 	a.nSkipCloseBody         = nIssues
-	a.nHttpTimeouts          = 0
+	a.nCtxTimeouts           = 0
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1272,17 +1264,15 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	testConns(t, a)
 
 	///////////////////////////////////////////////////////
-	// Timeouts.  The http timeout will trigger first if HttpTxPolicy is
-	// configured by the caller.  If HtppTxPolicy is not configured, only
-	// the context timeout is set (because default IdleConnTimeout is 0
-	// which means no http timeout).
+	// Timeouts.  There is no http timeout set, so the only timeout that
+	// will trigger will be the context timeout.
 
 	a.nTasks                 = nTasks
 	a.nSuccessRetries        = 0
 	a.nFailRetries           = 0
 	a.nSkipDrainBody         = 0
 	a.nSkipCloseBody         = 0
-	a.nHttpTimeouts          = nIssues
+	a.nCtxTimeouts           = nIssues
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
@@ -1290,7 +1280,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	// Timed out connections will close but we also need to account for
 	// the max idle connections allowed per host
 
-	openAfter = a.openAfterLaunch - a.nHttpTimeouts
+	openAfter = a.openAfterLaunch - a.nCtxTimeouts
 	if openAfter > a.maxIdleConnsPerHost {
 		openAfter = a.maxIdleConnsPerHost
 	}
@@ -1357,7 +1347,7 @@ func testConns(t *testing.T, a testConnsArg) {
 		a.nSkipDrainBody         = 0	// We want no issues
 		a.nSkipCloseBody         = 0	// We want no issues
 		a.nSuccessRetries        = 0	// We want no issues
-		a.nHttpTimeouts          = 0	// We want no issues
+		a.nCtxTimeouts           = 0	// We want no issues
 		a.nFailRetries           = 0	// We want no issues
 
 		// If we tested that exceeding IdleConnTimeout closes all connections
@@ -1445,16 +1435,16 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		}
 	}
 
-	// Configure any requested http timeouts and put at end of task list
+	// Configure any requested timeouts and put at end of task list
 
-	nHttpTimeouts = a.nHttpTimeouts	// this signals the handler
+	nCtxTimeouts = a.nCtxTimeouts	// this signals the handler
 
-	for i := len(tList) - 1; i > len(tList) - 1 - a.nHttpTimeouts; i-- {
+	for i := len(tList) - 1; i > len(tList) - 1 - a.nCtxTimeouts; i-- {
 		// This header is what identifies this request to the handler
 
 		tList[i].Request.Header.Set("Trs-Context-Timeout", "true")
 
-		// TODO: Could put nHttpTimeouts into header to reduce complexity
+		// TODO: Could put nCtxTimeouts into header to reduce complexity
 
 		if (logLevel == logrus.DebugLevel) {
 			t.Logf("Set request header %v for task %v",
@@ -1464,7 +1454,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		// Create a channel which will allow us to later signal the stalled
 		// server handlers to return the response
 
-		stallCancel = make(chan bool, a.nHttpTimeouts * 2)
+		stallCancel = make(chan bool, a.nCtxTimeouts * 2)
 	}
 
 	// Launch the task list
@@ -1543,11 +1533,11 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	// only done if we were asked to test timeouts.  We do it to verify that
 	// the completed tasks had their connections closed at the right time
 
-	if a.nHttpTimeouts > 0 {
-		t.Logf("Waiting for %v non-timeout tasks to complete", a.nTasks - a.nHttpTimeouts)
+	if a.nCtxTimeouts > 0 {
+		t.Logf("Waiting for %v non-timeout tasks to complete", a.nTasks - a.nCtxTimeouts)
 
 		nWaitedFor := 0
-		for i := 0; i < (a.nTasks - a.nHttpTimeouts); i++ {
+		for i := 0; i < (a.nTasks - a.nCtxTimeouts); i++ {
 			<-taskListChannel
 			tasksToWaitFor--
 			nWaitedFor++
@@ -1555,7 +1545,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 
 		t.Logf("Draining/closing non-timeout response bodies early and canceling their contexts")
 
-		for i := 0; i < len(tList) - a.nHttpTimeouts; i++ {
+		for i := 0; i < len(tList) - a.nCtxTimeouts; i++ {
 			if tList[i].Request.Response != nil && tList[i].Request.Response.Body != nil {
 				_, _ = io.Copy(io.Discard, tList[i].Request.Response.Body)
 
@@ -1577,7 +1567,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 		if nWaitedFor > a.maxIdleConnsPerHost {
 			oConns = a.maxIdleConnsPerHost
 		}
-		oConns += a.nHttpTimeouts
+		oConns += a.nCtxTimeouts
 
 		t.Logf("Testing connections after non-timeout request bodies closed (%v)", oConns)
 
@@ -1737,9 +1727,9 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	// handler.  Lets release them now so that we can cleanly stop the
 	// servers
 
-	if (a.nHttpTimeouts > 0) {
+	if (a.nCtxTimeouts > 0) {
 		t.Logf("Signaling stalled handlers ")
-		for i := 0; i < a.nHttpTimeouts * 2; i++ {
+		for i := 0; i < a.nCtxTimeouts * 2; i++ {
 			stallCancel <- true
 		}
 	}

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1570,7 +1570,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 					t.Logf("Response headers: %s", tList[i].Request.Response.Header)
 				}
 			}
-			tList[i].ContextCancel()
+			tList[i].contextCancel()
 		}
 
 		// Wait for underlying system to perform actions on connections

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -882,7 +882,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 	nTasks              := 4
 	nIssues             := 4
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy
-	maxIdleConns        := 1000	// PCS default when using HttpTxPolicy
+	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy
 	pcsStatusTimeout    := 30   // PCS default
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)
@@ -891,9 +891,9 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 
 	nTasks              := 1000
-	nIssues             := 10
+	nIssues             := 5
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy
-	maxIdleConns        := 1000	// PCS default when using HttpTxPolicy
+	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy
 	pcsStatusTimeout    := 30   // PCS default
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)
@@ -906,7 +906,7 @@ func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 	nTasks              := 1000
 	nIssues             := 4
 	maxIdleConnsPerHost := 1000 // Simulate more servers and larger connection pool
-	maxIdleConns        := 1000	// PCS default when using HttpTxPolicy
+	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy
 	pcsStatusTimeout    := 30   // PCS default
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)
@@ -919,7 +919,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 	nTasks              := 4000
 	nIssues             := 10
 	maxIdleConnsPerHost := 1000	// Simulate more servers and larger connection pool
-	maxIdleConns        := 1000	// PCS default when using HttpTxPolicy
+	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy
 	pcsStatusTimeout    := 30   // PCS default
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -482,6 +482,22 @@ func TestLaunchTimeout(t *testing.T) {
 //
 ///////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////
+//
+// WARNING!  The Go runtime behavior surrounding connections has changed in
+//			 more recent versions of Go.  Prior to version 1.23.X, if any
+//			 connection in the connection pool experiences a timeout, the
+//			 Go runtime closes all idle connections.  There is nothing we
+//			 can do about this in TRS, other than use a newer version of Go
+//			 that doesn't exhibit this (horrible) behavior.
+//
+//			 In our unit tests, we can change the version of Go used by
+//			 specifying it in the Makefile.  There are further instructions
+//			 in the Makefile on how to do this.
+//
+///////////////////////////////////////////////////////////////////////////
+
+
 // CustomConnState is a hook into httptest http servers that the unit tests
 // below spin up.  It allows is to log changes to connection states.  This
 // is critical when debugging connection state issues

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -934,7 +934,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
 //	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
-	nTasks              := 2000
+	nTasks              := 4000
 	nIssues             := 10
 	maxIdleConnsPerHost := 1000	// Simulate more servers and larger connection pool
 	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy
@@ -1157,8 +1157,10 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 
 	if a.nTasks <= 1000 && a.nFailRetries < 10 {
 		retrySleep = 5
-	} else {
+	} else if a.nTasks < 4000 && a.nFailRetries < 10 {
 		retrySleep = 9
+	} else {
+		retrySleep = 20
 	}
 
 	testConns(t, a)

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -216,6 +216,10 @@ func launchHandler(w http.ResponseWriter, req *http.Request) {
 		// Delay retry based on test requirement
 		time.Sleep(time.Duration(retrySleep) * time.Second)
 
+		// Clear retrySleep so next retry is immediate - Yes there will be
+		// many requests doing the same thing but that's ok
+		retrySleep = 0
+
 		w.Header().Set("Content-Type","application/json")
 		w.Header().Set("Retry-After","1")
 		//w.Header().Set("Connection","keep-alive")
@@ -1155,10 +1159,10 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	// SHould probably make retrySleep an initialRetrySleep so we only
 	// sleep once to avoid the issue
 
-	if a.nTasks <= 1000 && a.nFailRetries < 10 {
+	if a.nTasks <= 1000 {
 		retrySleep = 5
-	} else if a.nTasks < 4000 && a.nFailRetries < 10 {
-		retrySleep = 9
+	} else if a.nTasks <= 4000 {
+		retrySleep = 10
 	} else {
 		retrySleep = 20
 	}

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1143,10 +1143,20 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 
 	a.openAtStart            = 0
 	a.openAfterLaunch        = a.nTasks
+
+/// NEW
+	a.openAfterTasksComplete = a.maxIdleConnsPerHost - a.nFailRetries
+	a.openAfterBodyClose     = a.openAfterTasksComplete
+	a.openAfterCancel        = a.openAfterTasksComplete
+	a.openAfterClose         = a.openAfterTasksComplete
+///
+/*
+
 	a.openAfterTasksComplete = a.maxIdleConnsPerHost	// successful tasks closed bodies already
 	a.openAfterBodyClose     = a.maxIdleConnsPerHost
 	a.openAfterCancel        = a.maxIdleConnsPerHost
 	a.openAfterClose         = a.maxIdleConnsPerHost
+*/
 
 	if a.nTasks < 1000 && a.nFailRetries < 10 {
 		retrySleep = 10	// So retries complete after
@@ -1244,13 +1254,18 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	// Truncate the good connections down to MaxIdleConnsPerHost
 	// plus whatever connections are yucky
 
+/// NEW
+	a.openAfterCancel        = a.maxIdleConnsPerHost
+	a.openAfterClose         = a.maxIdleConnsPerHost
+///
+/*
+
 	openAfter = a.nTasks - a.nSkipDrainBody
 	if openAfter > a.maxIdleConnsPerHost {
 		openAfter = a.maxIdleConnsPerHost
 	}
 	openAfter = openAfter + a.nSkipDrainBody
 
-	a.openAfterBodyClose     = openAfter
 	a.openAfterCancel        = openAfter
 
 	// Unclosed bodies will now be closed by tloc.Close()
@@ -1260,6 +1275,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	} else {
 		a.openAfterClose     = openAfter
 	}
+*/
 
 	testConns(t, a)
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -934,7 +934,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
 //	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
-	nTasks              := 4000
+	nTasks              := 2000
 	nIssues             := 10
 	maxIdleConnsPerHost := 1000	// Simulate more servers and larger connection pool
 	maxIdleConns        := 4000	// PCS default when using HttpTxPolicy

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -819,7 +819,7 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // if they updated to the latest TRS without configuring the transport,
 // which is a newer feature of TRS.
 
-func JoshOne(t *testing.T) {
+func TestOne(t *testing.T) {
 
 	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1
@@ -827,7 +827,7 @@ func JoshOne(t *testing.T) {
 	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
 }
 
-func JoshTwo(t *testing.T) {
+func TestTwo(t *testing.T) {
 
 	nTasks  := 3	// default MaxIdleConnsPerHost
 	nIssues := 1
@@ -835,7 +835,7 @@ func JoshTwo(t *testing.T) {
 	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
 }
 
-func JoshThree(t *testing.T) {
+func TestThree(t *testing.T) {
 
 	nTasks  := 4	// default MaxIdleConnsPerHost
 	nIssues := 1

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -823,8 +823,7 @@ func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
 //	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
-	nTasks := 1
-//	nTasks  := 2	// default MaxIdleConnsPerHost
+	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1
 
 	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -873,6 +873,9 @@ func testConnsWithNoHttpTxPolicy(t *testing.T, nTasks int, nIssues int) {
 // configuration for most of these.
 
 func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
+
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+
 	nTasks              := 4
 	nIssues             := 4
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy
@@ -893,13 +896,14 @@ func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
 }
 
 func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
+
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+
 	nTasks              := 1000
 	nIssues             := 4
 	maxIdleConnsPerHost := 1000 // Simulate more servers and larger connection pool
 	maxIdleConns        := 1000	// PCS default when using HttpTxPolicy
 	pcsStatusTimeout    := 30   // PCS default
-
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	testConnsWithHttpTxPolicy(t, nTasks, nIssues, maxIdleConnsPerHost, maxIdleConns, pcsStatusTimeout)
 }
@@ -1715,7 +1719,7 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	// We likely have many connections open and idle.  If requested, pause
 	// until IdleConnTimeout expires so that we verify they then close
 
-	if (a.testIdleConnTimeout) {
+	if a.testIdleConnTimeout && a.tListProto.CPolicy.Tx.Enabled {
 		// TODO: Should also comfirm no client "other" connections as well
 		t.Logf("Testing connections after idleConnTimeout")
 

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -189,11 +189,11 @@ func hasTRSStallHeader(r *http.Request) bool {
 //	  response
 //	* Return a successful response immediately
 
-var handlerLogger *testing.T	// Allows logging in the handlers
-var handlerSleep int    = 2 // time to sleep to simulate network/BMC delays
-var retrySleep int      = 0 // time to sleep before returning 503 for retry
-var nRetries int32      = 0 // how many retries before returning success
-var nCtxTimeouts int    = 0 // how many context timeouts
+var handlerLogger *testing.T // Allows logging in the handlers
+var handlerSleep int    = 2  // time to sleep to simulate network/BMC delays
+var retrySleep int      = 0  // time to sleep before returning 503 for retry
+var nRetries int32      = 0  // how many retries before returning success
+var nCtxTimeouts int    = 0  // how many context timeouts
 
 func launchHandler(w http.ResponseWriter, req *http.Request) {
 	if (logLevel >= logrus.TraceLevel) {
@@ -747,7 +747,7 @@ type testConnsArg struct {
 	nSkipCloseBody         int       // Number of response bodies to skip closing
 	nCtxTimeouts           int       // Number of context timeouts
 	testIdleConnTimeout    bool 	 // Test idle connection timeout
-	runSecondTaskList	   bool      // Run a second task list after the first with same server
+	runSecondTaskList      bool      // Run a second task list after the first with same server
 	openAtStart            int       // Expected number of ESTAB connections at beginning
 	openAfterLaunch        int       // Expected number of ESTAB connections after Launch()
 	openAfterTasksComplete int       // Expected number of ESTAB connections after all tasks complete
@@ -1370,10 +1370,10 @@ func testConns(t *testing.T, a testConnsArg) {
 
 		if (a.testIdleConnTimeout) {
 			// They should have all timeed out and closed
-			a.openAtStart        = 0
+			a.openAtStart = 0
 		} else {
 			// What was open at the end of the last run should still be open
-			a.openAtStart        = a.openAfterClose
+			a.openAtStart = a.openAfterClose
 		}
 
 		// Carry forward the same number of tasks.  Since there will be no

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -819,22 +819,6 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // if they updated to the latest TRS without configuring the transport,
 // which is a newer feature of TRS.
 
-func TestOne(t *testing.T) {
-
-	nTasks  := 2	// default MaxIdleConnsPerHost
-	nIssues := 1
-
-	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
-}
-
-func TestTwo(t *testing.T) {
-
-	nTasks  := 3	// default MaxIdleConnsPerHost
-	nIssues := 1
-
-	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)
-}
-
 func TestThree(t *testing.T) {
 
 	nTasks  := 4	// default MaxIdleConnsPerHost
@@ -1274,6 +1258,7 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	if openAfter > a.maxIdleConnsPerHost {
 		openAfter = a.maxIdleConnsPerHost
 	}
+	openAfter = openAfter + a.nSkipDrainBody
 
 	a.openAfterCancel        = openAfter
 	a.openAfterClose         = openAfter

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -821,9 +821,10 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 
 func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
-	nTasks  := 2	// default MaxIdleConnsPerHost
+	nTasks := 1
+//	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1
 
 	testConnsWithNoHttpTxPolicy(t, nTasks, nIssues)

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -27,7 +27,6 @@ import (
 	"bytes"
 	"encoding/pem"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -1420,9 +1419,6 @@ func runTaskList(t *testing.T, tloc *TRSHTTPLocal, a testConnsArg, srv *httptest
 	t.Logf("Calling tloc.CreateTaskList() to create %v tasks for URL %v", a.nTasks, srv.URL)
 	tList := tloc.CreateTaskList(a.tListProto, a.nTasks)
 
-for i := 0; i < len(tList); i++ {
-  t.Errorf("====> TEST 1: tsk %v has pointer %s", tList[i].id, fmt.Sprintf("%p", &tList[i]))
-}
 	// Configure any requested retries and put at start of task list
 
 	nRetries = a.nSuccessRetries	// this signals the handler
@@ -1620,10 +1616,6 @@ for i := 0; i < len(tList); i++ {
 
 	for _, tsk := range(tList) {
 		// Skip closing any requested response bodies
-t.Errorf("====> TEST 2: tsk %v has pointer %s rsp %s rsp.body %s", tsk.id, 
-         fmt.Sprintf("%p", &tsk),
-         fmt.Sprintf("%p", &tsk.Request.Response),
-         fmt.Sprintf("%p", &tsk.Request.Response.Body))
 
 		if nBodyClosesSkipped < a.nSkipCloseBody {
 			if tsk.Request.Response != nil && tsk.Request.Response.Body != nil {

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -485,9 +485,9 @@ func TestLaunchTimeout(t *testing.T) {
 ///////////////////////////////////////////////////////////////////////////
 //
 // WARNING!  The Go runtime behavior surrounding connections has changed in
-//			 more recent versions of Go.  Prior to version 1.23.X, if any
+//			 more recent versions of Go.  Prior to version 1.23, if any
 //			 connection in the connection pool experiences a timeout, the
-//			 Go runtime closes all idle connections.  There is nothing we
+//			 Go runtime closes ALL idle connections.  There is nothing we
 //			 can do about this in TRS, other than use a newer version of Go
 //			 that doesn't exhibit this (horrible) behavior.
 //

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -804,6 +804,9 @@ func logConnTestHeader(t *testing.T, a testConnsArg) {
 // which is a newer feature of TRS.
 
 func TestConnsWithNoHttpTxPolicy_Idle(t *testing.T) {
+
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+
 	nTasks  := 2	// default MaxIdleConnsPerHost
 	nIssues := 1
 
@@ -886,6 +889,7 @@ func TestConnsWithHttpTxPolicy_PcsSmallIdle(t *testing.T) {
 }
 
 func TestConnsWithHttpTxPolicy_PcsSmallModeratlyBusy(t *testing.T) {
+
 	nTasks              := 1000
 	nIssues             := 10
 	maxIdleConnsPerHost := 4	// PCS default when using HttpTxPolicy

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -936,7 +936,7 @@ func TestConnsWithHttpTxPolicy_PcsSimulatedMedium(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
-//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks              := 4000
 	nIssues             := 10
@@ -949,10 +949,10 @@ func TestConnsWithHttpTxPolicy_PcsSmallBusy(t *testing.T) {
 
 func TestConnsWithHttpTxPolicy_PcsLargeBusy(t *testing.T) {
 
-	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
+//	t.Skip()	/***************** REMOVE TO RUN TEST *****************/
 
 	nTasks              := 8000
-	nIssues             := 10
+	nIssues             := 1000
 	maxIdleConnsPerHost := 8000  // We're only using one Host server so pretend
 	maxIdleConns        := 8000  // 8000 requests / 4 per host = 2000 BMCs
 	pcsStatusTimeout    := 60    // Increase for pitiful unit test vm 
@@ -1155,9 +1155,6 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.openAfterClose         = a.maxIdleConnsPerHost
 
 	// Slow down the retries so that the completing tasks finish up first.
-	// Don't slow down too much though or we'll get a context timeout.
-	// SHould probably make retrySleep an initialRetrySleep so we only
-	// sleep once to avoid the issue
 
 	if a.nTasks <= 1000 {
 		retrySleep = 5

--- a/pkg/trs_http_api/trshttp_local_test.go
+++ b/pkg/trs_http_api/trshttp_local_test.go
@@ -1169,18 +1169,18 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	a.openAfterLaunch        = a.nTasks
 
 /// NEW
+/*
 	a.openAfterTasksComplete = a.maxIdleConnsPerHost - a.nFailRetries
 	a.openAfterBodyClose     = a.openAfterTasksComplete
 	a.openAfterCancel        = a.openAfterTasksComplete
 	a.openAfterClose         = a.openAfterTasksComplete
+*/
 ///
-/*
 
 	a.openAfterTasksComplete = a.maxIdleConnsPerHost	// successful tasks closed bodies already
 	a.openAfterBodyClose     = a.maxIdleConnsPerHost
 	a.openAfterCancel        = a.maxIdleConnsPerHost
 	a.openAfterClose         = a.maxIdleConnsPerHost
-*/
 
 	if a.nTasks < 1000 && a.nFailRetries < 10 {
 		retrySleep = 10	// So retries complete after
@@ -1278,11 +1278,12 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	// Truncate the good connections down to MaxIdleConnsPerHost
 	// plus whatever connections are yucky
 
+/*
 /// NEW
 	a.openAfterCancel        = a.maxIdleConnsPerHost
 	a.openAfterClose         = a.maxIdleConnsPerHost
 ///
-/*
+*/
 
 	openAfter = a.nTasks - a.nSkipDrainBody
 	if openAfter > a.maxIdleConnsPerHost {
@@ -1299,7 +1300,6 @@ func testConnsPrep(t *testing.T, a testConnsArg, nTasks int, nIssues int) {
 	} else {
 		a.openAfterClose     = openAfter
 	}
-*/
 
 	testConns(t, a)
 


### PR DESCRIPTION
### Summary and Scope

A variety of changes, mostly in support of PCS experiencing scaling issues in the field.  Details are as follows:

- TRS now supports configuration of connection counts and timeouts by callers
- TRS no longer closes all idle connections when http or contexts time out
- TRS no longer closes all idle connections when request retry limits are reached
- Reworked several sections of code for clarity and reduced code duplication
- Fixed bug where contexts were never being cancelled which lead to resource leaks
- Fixed bug to prevent 2nd request if 1st request's context timed out or canceled
- Additional tracing added for debug purposes
- Unit tests: Now run in verbose mode so failures are more easily analyzed
- Unit tests: Enabled TRS logging from inside unit tests
- Unit tests: Error signature changed to make identifying errors easier
- Unit tests: Reworked some existing unit tests
- Unit tests: Numerous unit tests added to test connection states
- Update required version of Go to 1.23 to avoid [ https://github.com/golang/go/issues/59017](https://github.com/golang/go/issues/59017)

One thing to note about adding support for connections pools, this only provides the capability on the client side, for users of TRS.  Remote servers (or intermediate firewalls, proxies, etc) may not be configured, or desire, to maintain open idle connections for a period of time.  We discovered that while some BMCs kept connections open, others didn't.

The PCS PR needing these changes:  [https://github.com/Cray-HPE/hms-power-control/pull/57](https://github.com/Cray-HPE/hms-power-control/pull/57)

The PCS helm chart PR:  [https://github.com/Cray-HPE/hms-power-control-charts/pull/38](https://github.com/Cray-HPE/hms-power-control-charts/pull/38)

### Issues and Related PRs

* Resolves [CASMHMS-6299](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6299)

### Testing

Test description:

Testing was two-pronged, unit testing and testing on a live system.  The majority of testing was done through the unit test framework.  Extensive unit tests were added for all aspects of the connection lifecycle.  Many of the tests are not run in the build pipeline because the build pipeline limits the total unit test time to 10 minutes.  Developers making changes in the future should (a) enable/disable each test so that it can confirm no regressions, or (b) and probably more appropriately, move the connection unit tests into the integration test framework in the build pipeline.

These changes were also tested alongside PCS changes on both `mug` and `rocket`.  Rocket is a CSM 1.5 system and mug is a CSM 1.6 system.  Additionally, mug was running several thousand simulated BMCs on compute nodes so that the scaling aspects of these changes could be tested.  All standard PCS operations were confirmed to continue working.

While we do not have any systems internally that are able to reproduce all of the problems at customer sites, we believe this change will go a long ways towards improving most of the issues being experienced.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N (not deployable on its own)
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N (not deployable on its own)
- Was downgrade tested? If not, why? N (not deployable on its own)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable